### PR TITLE
Add missing dependency to Guava.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This extension works only with the standalone machine agent.
 
+[![Build Status](https://travis-ci.org/MoriTanosuke/activemq-monitoring-extension.svg)](https://travis-ci.org/MoriTanosuke/activemq-monitoring-extension)
+
 ##Use Case
 
 ActiveMQ is an open source, JMS 1.1 compliant, message-oriented middleware (MOM) from the Apache Software Foundation that provides high-availability, performance, scalability, reliability and security for enterprise messaging. 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>17.0</version>
+    </dependency>
   </dependencies>
   
   <build>
@@ -164,5 +169,5 @@
     <scm>
         <connection>scm:https://github.com/Appdynamics/activemq-monitoring-extension.git</connection>
     </scm>
-    
+
 </project>


### PR DESCRIPTION
I tried to build the project today using Maven 3.3.3 and Maven 3.2.3, but it kept failing. I added the missing dependency to Google Guava and that fixed the build for me.

I picked version _17.0_ randomly, so if that's not what you were using, please modify the PR and add the version you intended to use.
