### PR TITLE
Add missing dependency to Guava.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>17.0</version>
+    </dependency>
   </dependencies>
   
   <build>
@@ -164,5 +169,5 @@
     <scm>
         <connection>scm:https://github.com/Appdynamics/activemq-monitoring-extension.git</connection>
     </scm>
-    
+
 </project>


### PR DESCRIPTION
I tried to build the project today using Maven 3.3.3 and Maven 3.2.3, but it kept failing. I added the missing dependency to Google Guava and that fixed the build for me.

I picked version 17.0 randomly, so if that's not what you were using, please modify the PR and add the version you intended to use.
